### PR TITLE
Remove config_local.<username>.php at startup

### DIFF
--- a/root/etc/cont-init.d/40-config
+++ b/root/etc/cont-init.d/40-config
@@ -8,7 +8,7 @@ mkdir -p \
 [[ ! -e /var/www/localhost/cops ]] && \
 	ln -s /usr/share/webapps/cops /var/www/localhost/cops
 
-#clear previous config
+# clear previous config
 rm /var/www/localhost/cops/config_local.*.php
 
 # copy config

--- a/root/etc/cont-init.d/40-config
+++ b/root/etc/cont-init.d/40-config
@@ -8,6 +8,9 @@ mkdir -p \
 [[ ! -e /var/www/localhost/cops ]] && \
 	ln -s /usr/share/webapps/cops /var/www/localhost/cops
 
+#clear previous config
+rm /var/www/localhost/cops/config_local.*.php
+
 # copy config
 [[ ! -e /config/config_local.php ]] && \
 	cp /defaults/config_local.php /config/config_local.php


### PR DESCRIPTION
Remove config_local.<username>.php at start then copy back from /config to stop accumulation of potentially unused (and unbeknowst) user profiles.
