### PR TITLE
FIX: update rewrite rules

### DIFF
--- a/root/defaults/default
+++ b/root/defaults/default
@@ -11,7 +11,7 @@ server {
     index index.php;
 
     #Useful only for Kobo reader
-    location /cops/ {
+    location / {
           rewrite ^/download/(\d+)/(\d+)/.*\.(.*)$ /fetch.php?data=$1&db=$2&type=$3 last;
           rewrite ^/download/(\d+)/.*\.(.*)$ /fetch.php?data=$1&type=$2 last;
           break;


### PR DESCRIPTION
As the root is set to `/var/www/localhost/cops`, the location for rewriting should not include "/cops/" as this will never be met. We need just "/" here.

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-cops/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
Without URL rewriting, FBReader and Librera Reader Android apps do not work correctly with COPS.

- FBReader can't open the files because the extension is missing on the downloaded file
- Librera Reader can display the file but the filename is something like `fetch.php?data=...`

When setting `cops_use_url_rewriting`, I get 404 without this patch.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
After changing  `cops_use_url_rewriting` in my `config_local.php` with this patch included, both applications worked correctly:

- FBReader opens downloaded files
- Librera Reader displays the correct file names

I tested it with CBR and CBZ files.
## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->

Now that I see it, it could be that this fixes #31.