### PR TITLE
Fix incorrect CPU arch used in Dockerfile.aarch64

### DIFF
--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM ghcr.io/linuxserver/baseimage-alpine-nginx:3.18
+FROM ghcr.io/linuxserver/baseimage-alpine-nginx:arm64v8-3.18
 
 # set version label
 ARG BUILD_DATE


### PR DESCRIPTION
Regression from https://github.com/linuxserver/docker-cops/pull/43
