### PR TITLE
Fix rewriting rules default site conf - see linuxserver/docker-cops#31

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -70,6 +70,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "07.05.24:", desc: "Existing users should verify: site-confs/default.conf - Fix rewriting rules default site conf." }
   - { date: "20.03.24:", desc: "Rebase to Alpine 3.19." }
   - { date: "25.12.23:", desc: "Existing users should update: site-confs/default.conf - Cleanup default site conf." }
   - { date: "11.08.23:", desc: "Undeprecate and add new branch with mikespub fork which is actively maintained." }

--- a/root/defaults/nginx/site-confs/default.conf.sample
+++ b/root/defaults/nginx/site-confs/default.conf.sample
@@ -1,4 +1,4 @@
-## Version 2023/12/25 - Changelog: https://github.com/linuxserver/docker-cops/commits/master/root/defaults/nginx/site-confs/default.conf.sample
+## Version 2024/05/07 - Changelog: https://github.com/linuxserver/docker-cops/commits/master/root/defaults/nginx/site-confs/default.conf.sample
 
 server {
     listen 80 default_server;
@@ -14,10 +14,20 @@ server {
     root /app/www/public;
     index index.html index.htm index.php;
 
-    #Useful only for Kobo reader
-    location /cops/ {
+    #URL rewriting with COPS - see https://github.com/seblucas/cops/wiki/Url-Rewriting-with-COPS
+    location /download/ {
+        rewrite ^/download/(\d+)/(\d+)/.*\.kepub\.epub$ /fetch.php?data=$1&db=$2&type=epub last;
         rewrite ^/download/(\d+)/(\d+)/.*\.(.*)$ /fetch.php?data=$1&db=$2&type=$3 last;
+        rewrite ^/download/(\d+)/.*\.kepub\.epub$ /fetch.php?data=$1&type=epub last;
         rewrite ^/download/(\d+)/.*\.(.*)$ /fetch.php?data=$1&type=$2 last;
+        break;
+    }
+
+    location /view/ {
+        rewrite ^/view/(\d+)/(\d+)/.*\.kepub\.epub$ /fetch.php?data=$1&db=$2&type=epub&view=1 last;
+        rewrite ^/view/(\d+)/(\d+)/.*\.(.*)$ /fetch.php?data=$1&db=$2&type=$3&view=1 last;
+        rewrite ^/view/(\d+)/.*\.kepub\.epub$ /fetch.php?data=$1&type=epub&view=1 last;
+        rewrite ^/view/(\d+)/.*\.(.*)$ /fetch.php?data=$1&type=$2&view=1 last;
         break;
     }
 


### PR DESCRIPTION

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-cops/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

## Description:

Fix rewriting rules in default site conf according to COPS guidelines - see https://github.com/seblucas/cops/wiki/Url-Rewriting-with-COPS

## Benefits of this PR and context:

Fix downloading or viewing a book with any e-reader having difficulties fetching books from `/fetch?php?data=1&type=epub` links like Kobo, Moon+ Reader etc.

Closes issue #31 and replaces PR #33

## How Has This Been Tested?

Enable url rewriting in COPS `config_local.php` file

```php
$config['cops_use_url_rewriting'] = "1";
```

## Source / References:

See https://github.com/seblucas/cops/wiki/Url-Rewriting-with-COPS
