### PR TITLE
update rewriting rules

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -66,6 +66,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "24.09.24:", desc: "Existing users should verify: site-confs/default.conf - Update rewriting rules default site conf." }
   - { date: "14.09.24:", desc: "Ensure user config files have the right permissions." }
   - { date: "09.09.24:", desc: "In COPS 3.x, the config_local.php is being moved over to config/local.php and this container will automatically migrate it. Existing users should verify: config_local.php and/or config/local.php - define $config['cops_kepubify_path'] if they want to use it" }
   - { date: "28.08.24:", desc: "Add kepubify tool to update metadata for Kobo - see mikespub-org/seblucas-cops#77" }

--- a/root/defaults/nginx/site-confs/default.conf.sample
+++ b/root/defaults/nginx/site-confs/default.conf.sample
@@ -15,18 +15,18 @@ server {
 
     #URL rewriting with COPS - see https://github.com/seblucas/cops/wiki/Url-Rewriting-with-COPS
     location /download/ {
-        rewrite ^/download/(\d+)/(\d+)/.*\.kepub\.epub$ /fetch.php?data=$1&db=$2&type=epub last;
-        rewrite ^/download/(\d+)/(\d+)/.*\.(.*)$ /fetch.php?data=$1&db=$2&type=$3 last;
-        rewrite ^/download/(\d+)/.*\.kepub\.epub$ /fetch.php?data=$1&type=epub last;
-        rewrite ^/download/(\d+)/.*\.(.*)$ /fetch.php?data=$1&type=$2 last;
+        #rewrite ^/download/(\d+)/(\d+)/.*\.kepub\.epub$ /index.php/fetch/$2/$1/ignore.epub last;
+        rewrite ^/download/(\d+)/(\d+)/.*\.(.*)$ /index.php/fetch/$2/$1/ignore.$3 last;
+        #rewrite ^/download/(\d+)/.*\.kepub\.epub$ /index.php/fetch/0/$1/ignore.epub last;
+        rewrite ^/download/(\d+)/.*\.(.*)$ /index.php/fetch/0/$1/ignore.$2 last;
         break;
     }
 
     location /view/ {
-        rewrite ^/view/(\d+)/(\d+)/.*\.kepub\.epub$ /fetch.php?data=$1&db=$2&type=epub&view=1 last;
-        rewrite ^/view/(\d+)/(\d+)/.*\.(.*)$ /fetch.php?data=$1&db=$2&type=$3&view=1 last;
-        rewrite ^/view/(\d+)/.*\.kepub\.epub$ /fetch.php?data=$1&type=epub&view=1 last;
-        rewrite ^/view/(\d+)/.*\.(.*)$ /fetch.php?data=$1&type=$2&view=1 last;
+        #rewrite ^/view/(\d+)/(\d+)/.*\.kepub\.epub$ /index.php/inline/$2/$1/ignore.epub last;
+        rewrite ^/view/(\d+)/(\d+)/.*\.(.*)$ /index.php/inline/$2/$1/ignore.$3 last;
+        #rewrite ^/view/(\d+)/.*\.kepub\.epub$ /index.php/inline/0/$1/ignore.epub last;
+        rewrite ^/view/(\d+)/.*\.(.*)$ /index.php/inline/0/$1/ignore.$2 last;
         break;
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-cops/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->

Update nginx rewriting rules in default.conf.sample to use /index.php/fetch handler instead of deprecated /fetch.php endpoint

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->

In line with COPS 3.x route urls instead of old endpoints

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Docker build & run

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->

https://github.com/mikespub-org/seblucas-cops/releases/tag/3.1.1
